### PR TITLE
Add correct dev baseurl & change guidelines in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This README would normally document whatever steps are necessary to get your app
 ```
  npm install
  bower install
- mv HINTGruntfile.js Gruntfile.js
+ cp HINTGruntfile.js Gruntfile.js
  grunt
 ```
 

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ logo: assets/images/car.svg
 
 service-layout: "third"
 
-tagline: xSite Tagline plus some text
+tagline: Site Tagline plus some text
 call-to-action: Call to Action
 section-1-image: assets/images/image-3.jpg
 intro-image: assets/images/image-4.jpg

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ logo: assets/images/car.svg
 
 service-layout: "third"
 
-tagline: Site Tagline plus some text
+tagline: xSite Tagline plus some text
 call-to-action: Call to Action
 section-1-image: assets/images/image-3.jpg
 intro-image: assets/images/image-4.jpg

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,7 +1,4 @@
 url: ""
-#baseurl: /jekyll-template/_site
-baseurl: "/cw-master/_site"
+baseurl: "/example-business-template/_site"
 paginate: 10
 production: false
-#category_dir: "/blog"
-#paginate_path: /cafe-showcase/_site/blog/page:num/


### PR DESCRIPTION
The correct baseurl is needed for the dev environment.
We should mv rather than cp `HINTGruntfile.js` so that the original is retained as a point of reference.
